### PR TITLE
Refactor error management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ version = "0.1.1"
 dependencies = [
  "chrono",
  "clap",
+ "thiserror",
 ]
 
 [[package]]
@@ -383,6 +384,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.10",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ keywords = ["timetable"]
 [dependencies]
 clap = { version = "4.1.13", features = ["derive"] }
 chrono = "0.4.24"
-
+thiserror = "1.0.*"

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,9 +1,10 @@
 //! Specification of a timetable event
 
-use std::collections::HashMap;
-use std::str::FromStr;
-use std::fmt;
 use chrono::prelude::*;
+use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+use thiserror::Error;
 
 /// The type of a timetable event
 #[derive(Debug, PartialEq, Eq, Default)]
@@ -68,24 +69,60 @@ fn split_pairs(string: &str) -> HashMap<&str, &str> {
         .collect()
 }
 
+/// The parsing of an event failed.
+#[derive(Debug, Error)]
+pub enum ParsingError {
+    /// The duration setting could not be parsed as an integer.
+    #[error("could not parse duration: `{source}`")]
+    CouldNotParseDuration {
+        /// the underlying error
+        #[source]
+        source: <u32 as FromStr>::Err,
+    },
+
+    /// No setting named `name` was found in the input.
+    #[error("setting named `{name}` not found")]
+    SettingNotFound {
+        /// the setting name
+        name: String,
+    },
+
+    /// The input did not have empty-newline separated header and description.
+    #[error("could not split the header and description of the event")]
+    CouldNotSplit,
+}
+
 impl FromStr for Event {
-    type Err = ();
+    type Err = ParsingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let trimmed = s.trim();
         if let Some((header, description)) = trimmed.split_once("\n\n") {
             let settings = split_pairs(header);
-            let event_type = settings.get("type")
+            let event_type = settings
+                .get("type")
                 .as_ref()
+                // TODO: check if Type needs a refactor too.
                 .map_or(Type::Talk, |e| Type::from_str(e).unwrap_or_default());
             let title = settings.get("title").map_or("(no title)", |&e| e);
             let start_date = Local
-                .datetime_from_str(settings.get("date").expect("No `date` field found"),
-                    "%Y-%m-%d %H:%M")
+                .datetime_from_str(
+                    settings.get("date").expect("No `date` field found"),
+                    "%Y-%m-%d %H:%M",
+                )
                 .expect("Invalid date shape.");
-            let duration = settings.get("duration")
-                .map(|e| e.parse().expect("Could not parse duration."))
-                .expect("Could not get duration.");
+
+            let duration_name = String::from("duration");
+            let duration = settings
+                .get(duration_name.as_str())
+                .ok_or(ParsingError::SettingNotFound {
+                    name: duration_name,
+                })
+                .and_then(|duration_setting| {
+                    duration_setting
+                        .parse()
+                        .map_err(|err| ParsingError::CouldNotParseDuration { source: err })
+                })?;
 
             Ok(Self {
                 event_type,
@@ -95,7 +132,7 @@ impl FromStr for Event {
                 description: description.to_owned(),
             })
         } else {
-            Err(())
+            Err(ParsingError::CouldNotSplit)
         }
     }
 }

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -1,7 +1,7 @@
 //! Compilation passes
 
-pub mod parser;
 pub mod latex;
+pub mod parser;
 
 /// A trait definint compilation passes
 /// Compilation passes should be chainable

--- a/src/passes/latex.rs
+++ b/src/passes/latex.rs
@@ -19,6 +19,20 @@ pub struct BoundingBox {
     down_right: DateTime<Local>,
 }
 
+impl BoundingBox {
+    /// Get a datetime of the first day at 00:00 of the bounding box.
+    #[must_use]
+    pub fn first_day(&self) -> Option<DateTime<Local>> {
+        self.up_left.with_hour(0)?.with_minute(0)
+    }
+
+    /// Get a datetime of the last day at 00:00 of the bounding box.
+    #[must_use]
+    pub fn last_day(&self) -> Option<DateTime<Local>> {
+        self.down_right.with_hour(0)?.with_minute(0)
+    }
+}
+
 /// TODO Do not assume everything is in the same month
 /// Will find the bounding box (date, times) to generate a timetable
 fn find_bounding_box(events: &Vec<Event>) -> Option<BoundingBox> {
@@ -77,12 +91,9 @@ impl CompilingPass<Vec<Event>, String, TikzBackendCompilationError> for TikzFron
         let first_hour = bb.up_left.hour();
         let last_hour = bb.down_right.hour() + 1;
 
-        let day_count = (bb.down_right.with_hour(0).unwrap().with_minute(0).unwrap()
-            - bb.up_left.with_hour(0).unwrap().with_minute(0).unwrap())
-        .num_days()
-            + 1;
-
+        let day_count = (bb.last_day().unwrap() - bb.first_day().unwrap()).num_days() + 1;
         let day_end = day_count + 1;
+
         let mut r: String = r"\documentclass{standalone}
 \usepackage{tikz}
 

--- a/src/passes/latex.rs
+++ b/src/passes/latex.rs
@@ -22,41 +22,36 @@ pub struct BoundingBox {
 /// TODO Do not assume everything is in the same month
 /// Will find the bounding box (date, times) to generate a timetable
 fn find_bounding_box(events: &Vec<Event>) -> Option<BoundingBox> {
-    events.get(0).map(|first| {
+    events.get(0).and_then(|first| {
         let mut up_left = first.start_date;
         let mut down_right = first.start_date;
         for e in events {
             if e.start_date.time() < up_left.time() {
-                up_left = up_left.with_hour(e.start_date.hour()).unwrap();
-                up_left = up_left.with_minute(e.start_date.minute()).unwrap();
+                up_left = up_left.with_hour(e.start_date.hour())?;
+                up_left = up_left.with_minute(e.start_date.minute())?;
             }
             if e.start_date.date_naive() < up_left.date_naive() {
-                up_left = up_left.with_day(e.start_date.day()).unwrap();
+                up_left = up_left.with_day(e.start_date.day())?;
             }
             if (e.start_date + Duration::minutes(i64::from(e.duration))).time() > down_right.time()
             {
                 down_right = down_right
-                    .with_hour(e.start_date.hour())
-                    .unwrap()
+                    .with_hour(e.start_date.hour())?
                     .with_minute(e.start_date.minute())
-                    .map(|h| h.add(Duration::minutes(i64::from(e.duration))))
-                    .unwrap();
+                    .map(|h| h.add(Duration::minutes(i64::from(e.duration))))?;
             }
             if e.start_date.date_naive() > down_right.date_naive() {
                 down_right = down_right
-                    .with_day(e.start_date.day())
-                    .unwrap()
-                    .with_month(e.start_date.month())
-                    .unwrap()
-                    .with_year(e.start_date.year())
-                    .unwrap();
+                    .with_day(e.start_date.day())?
+                    .with_month(e.start_date.month())?
+                    .with_year(e.start_date.year())?;
             }
         }
 
-        BoundingBox {
+        Some(BoundingBox {
             up_left,
             down_right,
-        }
+        })
     })
 }
 

--- a/src/passes/parser.rs
+++ b/src/passes/parser.rs
@@ -1,9 +1,6 @@
 //! Parsing compilation passes
 
-use crate::{
-    passes::CompilingPass,
-    event::Event
-};
+use crate::{event::Event, passes::CompilingPass};
 
 use std::str::FromStr;
 
@@ -30,14 +27,10 @@ use std::str::FromStr;
 ///
 /// timetable = event , ( delimiter , event ) * ;
 /// ```
-pub struct ParseTimetable {
-}
+pub struct ParseTimetable {}
 
-impl CompilingPass<&str, Vec<Event>, ()> for ParseTimetable {
-    fn apply(s: &str) -> Result<Vec<Event>, ()> {
-    Ok(s
-        .split("---")
-        .filter_map(|e| Event::from_str(e).ok())
-        .collect())
+impl CompilingPass<&str, Vec<Event>, <Event as FromStr>::Err> for ParseTimetable {
+    fn apply(s: &str) -> Result<Vec<Event>, <Event as FromStr>::Err> {
+        s.split("---").map(Event::from_str).collect()
     }
 }


### PR DESCRIPTION
Until now, most errors were handled via `unwrap()` and gave no meaning to most `Result` return types. Moreover it was virtually impossible to debug any parsing error that would occur.

This merge request adds many things to error management:

* the use of [thiserror](https://docs.rs/thiserror/) to easily create an error type for each function in the project (when relevent)
* change from `()` error type to meaningful errors
* change from meaningless `Option`s to `Result` with specialized error types
* the main function correctly handle errors

In addition to that, the type `BoundingBox` has been added to encapsulate the logic of event bounds. This is still the starting point of this part of the refactoring process, but it helps a lot with managing errors that could occur when calling `with_hour()` and `with_minute()` on datetimes.