### PR TITLE
Make CompilingPass generic over the input only

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,9 +19,16 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::missing_crate_level_docs)]
 
-use crate::{passes::{latex::{TikzBackendCompilationError, TikzFrontend}, parser::ParseTimetable, PassInput}, event::Event};
+use crate::{
+    event::Event,
+    passes::{
+        latex::{TikzBackendCompilationError, TikzFrontend},
+        parser::ParseTimetable,
+        PassInput,
+    },
+};
 use clap::Parser;
-use std::{fs, io::Read, str::FromStr};
+use std::{fs, io::Read};
 
 pub mod event;
 pub mod passes;
@@ -40,8 +47,8 @@ impl PassInput for Vec<Event> {}
 
 fn generate_tikz(content: &str) -> Result<String, TikzBackendCompilationError> {
     content
-        .chain_pass::<ParseTimetable, Vec<Event>, <Event as FromStr>::Err>()?
-        .chain_pass::<TikzFrontend, String, TikzBackendCompilationError>()
+        .chain_pass::<ParseTimetable>()?
+        .chain_pass::<TikzFrontend>()
 }
 
 fn main() {
@@ -55,7 +62,7 @@ fn main() {
         },
         |filepath| fs::read_to_string(filepath).expect("Could not read file"),
     );
-    
+
     match generate_tikz(&content) {
         Ok(tikz) => println!("{tikz}"),
         Err(err) => eprintln!("{err}"),

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -5,23 +5,31 @@ pub mod parser;
 
 /// A trait defining compilation passes
 /// Compilation passes should be chainable
-pub trait CompilingPass<T, U, UE> {
+pub trait CompilingPass<T> {
+    /// Type of data that is returned by the pass if it succeeds.
+    type Residual;
+    /// Type of errors that the pass returns when it fails.
+    type Error;
+
     /// Transforms a given input of type T to a given output of type T
     ///
     /// # Errors
     ///
     /// May return errors if type is not compatible
-    fn apply(_: T) -> Result<U, UE>;
+    fn apply(_: T) -> Result<Self::Residual, Self::Error>;
 }
 
 /// A trait to be able to chain compilation passes
-pub trait PassInput : Sized {
+pub trait PassInput: Sized {
     /// Chain current element with a given compilation pass
     ///
     /// # Errors
     ///
     /// Can return a fitting error if a compilation pass cannot be applied.
-    fn chain_pass<P, U, E>(self) -> Result<U, E> where P: CompilingPass<Self, U, E> {
+    fn chain_pass<P>(self) -> Result<P::Residual, P::Error>
+    where
+        P: CompilingPass<Self>,
+    {
         P::apply(self)
     }
 }

--- a/src/passes/latex.rs
+++ b/src/passes/latex.rs
@@ -157,8 +157,11 @@ const LATEX_INTRO: &str = r"\documentclass{standalone}
 
     % First print a list of times.";
 
-impl CompilingPass<Vec<Event>, String, TikzBackendCompilationError> for TikzFrontend {
-    fn apply(events: Vec<Event>) -> Result<String, TikzBackendCompilationError> {
+impl CompilingPass<Vec<Event>> for TikzFrontend {
+    type Residual = String;
+    type Error = TikzBackendCompilationError;
+
+    fn apply(events: Vec<Event>) -> Result<Self::Residual, Self::Error> {
         const POSTAMBLE: &str = r"
 \end{tikzpicture}
 \end{document}";
@@ -241,4 +244,3 @@ impl CompilingPass<Vec<Event>, String, TikzBackendCompilationError> for TikzFron
         Ok(r)
     }
 }
-

--- a/src/passes/parser.rs
+++ b/src/passes/parser.rs
@@ -29,8 +29,11 @@ use std::str::FromStr;
 /// ```
 pub struct ParseTimetable {}
 
-impl CompilingPass<&str, Vec<Event>, <Event as FromStr>::Err> for ParseTimetable {
-    fn apply(s: &str) -> Result<Vec<Event>, <Event as FromStr>::Err> {
+impl CompilingPass<&str> for ParseTimetable {
+    type Residual = Vec<Event>;
+    type Error = <Event as FromStr>::Err;
+
+    fn apply(s: &str) -> Result<Self::Residual, Self::Error> {
         s.split("---").map(Event::from_str).collect()
     }
 }


### PR DESCRIPTION
The return type and error type are supposedly known when defining the pass. Thus they can be defined as associated types and not generics. This does not change much to the code of compilation passes, but it makes pass chaining a lot easier. Instead of using the silverfish operator with 3 generic parameters (the pass type, the return type, the error type), it is now used with only one parameter that is the pass type. The return and error types are determined using the pass' Residual and Error associated types.

Now a pass is defined this way:

```rust
impl CompilingPass for MyBackendPass {
    type Residual = String;
    type Error = MyBackendPassError;

    fn apply(input: MyIR) -> Result<Self::Residual, Self::Error> {
        // apply the pass
    }
}
```

And chain passes can be done easily as in [main.rs:50](https://github.com/Docteur-Lalla/timetable-language/blob/pass-chaining/src/main.rs#L50):

```rust
contents.chain_pass::<ParseTimetable>()?
        .chain_pass::<TikzFrontend>()
```