### PR TITLE
Simplify code of find_bounding_box

### DIFF
--- a/src/passes/latex.rs
+++ b/src/passes/latex.rs
@@ -68,7 +68,10 @@ impl BoundingBox {
         }
 
         if second.date_naive() < first.date_naive() {
-            res = res.with_day(second.day())?;
+            res = res
+                .with_day(second.day())?
+                .with_month(second.month())?
+                .with_year(second.year())?;
         }
 
         Some(res)


### PR DESCRIPTION
The function `find_bounding_box` had confusing code about creating the top-left and bottom-right bounds of the box. It has been extracted to separate methods of `BoundingBox`.

Moreover, the top-left datetime now inherits the month and year of the datetime it is built from whose date is the earliest.