### PR TITLE
Add support for multiple backends and add HTML backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "seri"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "seri"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = [
 	"Lugrim",
 	"Camille Le Bon",
 	"Amélie Gonzalez",
+	"Hugo Reymond",
 ]
 license = "ACSL"
 repository = "https://github.com/Lugrim/timetable-language"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,40 @@
-# TODO
+# Seri
+
+A way too much over-engineered timetable language compiler.
+
+## Running Seri
+
+Seri is written in Rust, so you need to install the Rust toolchain to run it.
+
+To generate a schedule from a file, run:
+```bash
+cargo run data/example.seri
+```
+
+You can also generate a schedule from stdin:
+```bash
+cat data/example.seri > cargo run
+```
+
+## Seri compiler command-line interface
+
+```
+Usage: seri [FILE] [OUTPUT_FORMAT]
+
+Arguments:
+  [FILE]           File to compile. If not present, will read from standard input
+  [OUTPUT_FORMAT]  Output format. Default  [default: tikz]
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+```
+
+## Seri language
+
+TODO : Write a proper language specification
+
+## TODO
 
 - [x] Refactor as a compiler structure
 	- [x] Refactor base code

--- a/README.md
+++ b/README.md
@@ -59,7 +59,13 @@ TODO : Write a proper language specification
 		- [x] minimal
 		- [x] Print day in header
 		- [ ] load preamble and postamble from files
-	- [ ] HTML
-		- [ ] minimal
+	- [x] HTML
+		- [x] minimal
+		- [ ] Automatically compute the number or days/hours of the seminar
+		- [ ] Handle event not starting on round hours
+		- [ ] Display the date on top of the planning
+		- [ ] Display the abstract next to the planning
+- [ ] Templating
+	- [ ] Add some real templating
 - [x] Documentation
 - [x] Put clippy in giga chad mode

--- a/README.md
+++ b/README.md
@@ -19,15 +19,17 @@ cat data/example.seri > cargo run
 ## Seri compiler command-line interface
 
 ```
-Usage: seri [FILE] [OUTPUT_FORMAT]
+Usage: seri [OPTIONS] [FILE]
 
 Arguments:
-  [FILE]           File to compile. If not present, will read from standard input
-  [OUTPUT_FORMAT]  Output format. Default  [default: tikz]
+  [FILE]  File to compile. If not present, will read from standard input
 
 Options:
-  -h, --help     Print help
-  -V, --version  Print version
+  -f, --format <FORMAT>      Output format [default: tikz]
+  -t, --template <TEMPLATE>  Template to use, if any
+  -o, --output <FILE>        Output file. If not present, will output to stdout
+  -h, --help                 Print help
+  -V, --version              Print version
 ```
 
 ## Seri language

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Seri
+# Seri
 
 A way too much over-engineered timetable language compiler.
 
-## Running Seri
+## Running Seri
 
 Seri is written in Rust, so you need to install the Rust toolchain to run it.
 
@@ -32,7 +32,7 @@ Options:
   -V, --version              Print version
 ```
 
-## Seri language
+## Seri language
 
 TODO : Write a proper language specification
 

--- a/data/template.html
+++ b/data/template.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>My template</title>
+    <style>
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+
+      }
+
+      table {
+        width: 100%;
+        max-width: 50rem;
+        font-family: -system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      }
+
+      th {
+        font-weight: normal;
+        border-top: thin dotted #ccc;
+      }
+
+      td {
+        font-size: 0.8rem;
+        font-weight: bold;
+        line-height: 1.4;
+        border-radius: 0.2rem;
+        transition: opacity 0.3s ease;
+        width: 40%;
+      }
+
+      td > span {
+        font-size: 0.8em;
+        font-weight: normal;
+        display: block;
+        width: 100%;
+      }
+
+      .meal {
+        background-color: #ffa726;
+      }
+      .fun {
+        background-color: #9ccc65;
+      }
+      .talk {
+        background-color: #ff8a65;
+      }
+      .other {
+        background-color: #b3e5fc;
+      }
+
+      .light {
+        color: #ccc;
+        font-weight: normal;
+      }
+    </style>
+  </head>
+  <body>
+    {{ CALENDAR }}
+  </body>
+</html>

--- a/src/event.rs
+++ b/src/event.rs
@@ -170,10 +170,12 @@ impl FromStr for Event {
                     .parse()
                     .map_err(|err| ParsingError::CouldNotParseDuration { source: err })
             })?;
-        let speakers = settings.get("speakers")
-            .map_or_else(Vec::new, |l| l.split(',').map(|s| s.trim().to_owned())
-                         .filter(|s| !s.is_empty())
-                         .collect());
+        let speakers = settings.get("speakers").map_or_else(Vec::new, |l| {
+            l.split(',')
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+                .collect()
+        });
 
         Ok(Self {
             event_type,

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,8 @@ struct Args {
     /// An optional path to a file
     #[arg(help = "File to compile. If not present, will read from standard input")]
     file: Option<String>,
+    #[arg(help = "Output format. Default ", default_value_t = String::from("tikz"))]
+    output_format: String,
 }
 
 impl PassInput for &str {}
@@ -49,6 +51,10 @@ fn generate_tikz(content: &str) -> Result<String, TikzBackendCompilationError> {
     content
         .chain_pass::<ParseTimetable>()?
         .chain_pass::<TikzBackend>()
+}
+
+fn generate_html(content: &str) -> Result<String, TikzBackendCompilationError> {
+    todo!();
 }
 
 fn main() {
@@ -63,8 +69,15 @@ fn main() {
         |filepath| fs::read_to_string(filepath).expect("Could not read file"),
     );
 
-    match generate_tikz(&content) {
-        Ok(tikz) => println!("{tikz}"),
-        Err(err) => eprintln!("{err}"),
+    match args.output_format.as_str() {
+        "tikz" => match generate_tikz(&content) {
+            Ok(tikz) => println!("{tikz}"),
+            Err(err) => eprintln!("{err}"),
+        },
+        "html" => match generate_html(&content) {
+            Ok(tikz) => println!("{tikz}"),
+            Err(err) => eprintln!("{err}"),
+        },
+        _ => eprintln!("Unknow format {}", args.output_format)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ struct Args {
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]
+#[allow(clippy::upper_case_acronyms)]
 enum Format {
     Tikz,
     HTML,
@@ -89,10 +90,9 @@ fn generate_html(
     options: HTMLBackendOptions,
     content: &str,
 ) -> Result<String, HTMLBackendCompilationError> {
-    HTMLBackend::configure(options);
     content
         .chain_pass::<ParseTimetable>()?
-        .chain_pass::<HTMLBackend>()
+        .chain_pass_with::<HTMLBackend, HTMLBackendOptions>(options)
 }
 
 /// Write the output to a file or to stdout

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,8 +141,8 @@ fn main() {
         Ok(data) => write_output(&args.output, data).unwrap_or_else(|e| {
             panic!(
                 "Couldn't write to file {}: {}",
-                &args.output.unwrap_or("stdout".to_string()),
-                e.to_string()
+                &args.output.unwrap_or_else(|| "stdout".to_string()),
+                e
             )
         }),
         Err(err) => eprintln!("{err}"),

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -6,7 +6,7 @@ pub mod parser;
 
 /// A trait defining compilation passes
 /// Compilation passes should be chainable
-pub trait CompilingPass<T> {
+pub trait CompilingPass<T, C=()> {
     /// Type of data that is returned by the pass if it succeeds.
     type Residual;
     /// Type of errors that the pass returns when it fails.
@@ -18,6 +18,17 @@ pub trait CompilingPass<T> {
     ///
     /// May return errors if type is not compatible
     fn apply(_: T) -> Result<Self::Residual, Self::Error>;
+
+    /// Transforms a given input of type T to a given output of type T given a
+    /// context
+    ///
+    /// # Errors
+    ///
+    /// May return errors if type is not compatible
+    fn apply_with(data: T, _: C) -> Result<Self::Residual, Self::Error> {
+        // The default implementation provided discards any context
+        Self::apply(data)
+    }
 }
 
 /// A trait to be able to chain compilation passes
@@ -32,5 +43,14 @@ pub trait PassInput: Sized {
         P: CompilingPass<Self>,
     {
         P::apply(self)
+    }
+
+    /// Chain current element with a given compilation pass with context data
+    ///
+    /// # Errors
+    ///
+    /// Can return a fitting error if a compilation pass cannot be applied.
+    fn chain_pass_with<P: CompilingPass<Self, U>, U>(self, ctx: U) -> Result<P::Residual, P::Error> {
+        P::apply_with(self, ctx)
     }
 }

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -1,5 +1,6 @@
 //! Compilation passes
 
+pub mod html;
 pub mod latex;
 pub mod parser;
 

--- a/src/passes/html.rs
+++ b/src/passes/html.rs
@@ -1,0 +1,87 @@
+//! HTML backend
+use crate::{event::Event, passes::CompilingPass};
+use chrono::Timelike;
+use std::{cmp::min, str::FromStr, sync::Mutex};
+use thiserror::Error;
+
+/// Backend outputing events to a standalone HTML document containing a timetable
+pub struct HTMLBackend {}
+
+/// Options for the HTML backend
+pub struct HTMLBackendOptions {
+    /// Path to the template file. If not set, the default template (`data/template.html`) will be used.
+    pub template_path: Option<String>,
+}
+
+/// Options of the HTML backend
+static OPTIONS: Mutex<HTMLBackendOptions> = Mutex::new(HTMLBackendOptions {
+    template_path: None,
+});
+
+/// Error that can occur during the compilation of the HTML backend
+#[derive(Debug, Error)]
+pub enum HTMLBackendCompilationError {
+    /// The event could not be parsed.
+    #[error(transparent)]
+    CouldNotParseEvent(#[from] <Event as FromStr>::Err),
+    /// The event could not be parsed.
+    #[error("Error while trying to read the template file: {0}")]
+    CouldNotReadTemplate(#[from] std::io::Error),
+}
+
+fn get_template() -> Result<String, HTMLBackendCompilationError> {
+    let options = OPTIONS.lock().unwrap();
+    if let Some(path) = &options.template_path {
+        match std::fs::read_to_string(path) {
+            Ok(template) => Ok(template),
+            Err(err) => Err(HTMLBackendCompilationError::CouldNotReadTemplate(err)),
+        }
+    } else {
+        Ok(include_str!("../../data/template.html").to_string())
+    }
+}
+
+fn event_to_string(event: &Event) -> String {
+    let duration = std::cmp::max(event.duration / 30, 1);
+    let class = event.event_type.to_string();
+    let mut res = String::from(format!("\t\t<td class=\"{class}\" rowspan=\"{duration}\">"));
+    let (title, _) = event.title.split_at(min(event.title.len(), 25));
+    res.push_str(format!("{}", title).as_str());
+    res.push_str("<span>");
+    for speaker in &event.speakers {
+        res.push_str(speaker.as_str());
+    }
+    res.push_str("</span></td>\n");
+    res
+}
+
+impl HTMLBackend {
+    /// Configure the HTML backend
+    pub fn configure(opts: HTMLBackendOptions) {
+        *OPTIONS.lock().unwrap() = opts;
+    }
+}
+
+impl CompilingPass<Vec<Event>> for HTMLBackend {
+    type Residual = String;
+    type Error = HTMLBackendCompilationError;
+
+    fn apply(events: Vec<Event>) -> Result<Self::Residual, Self::Error> {
+        let template = get_template()?;
+        let mut str = String::new();
+        str.push_str("<table><tbody>\n");
+        for i in 9..21 {
+            str.push_str(format!("\t<tr><th>{}:00</th>", i).as_str());
+            for event in events
+                .iter()
+                .filter(|ev| ev.start_date.hour() >= i && ev.start_date.hour() < i + 1)
+            {
+                str.push_str(event_to_string(&event).as_str());
+            }
+            str.push_str("</tr>\n");
+            str.push_str(format!("\t<tr><th class=\"light\">{}:30</th></tr>\n", i).as_str());
+        }
+        str.push_str("</tbody></table>\n");
+        Ok(template.replace("{{ CALENDAR }}", &str))
+    }
+}

--- a/src/passes/html.rs
+++ b/src/passes/html.rs
@@ -1,7 +1,7 @@
 //! HTML backend
 use crate::{event::Event, passes::CompilingPass};
 use chrono::Timelike;
-use std::{cmp::min, str::FromStr, sync::Mutex};
+use std::{cmp::min, str::FromStr};
 use thiserror::Error;
 
 /// Backend outputing events to a standalone HTML document containing a timetable
@@ -18,11 +18,6 @@ pub struct HTMLBackendOptions {
     pub template_path: Option<String>,
 }
 
-/// Options of the HTML backend
-static OPTIONS: Mutex<HTMLBackendOptions> = Mutex::new(HTMLBackendOptions {
-    template_path: None,
-});
-
 /// Error that can occur during the compilation of the HTML backend
 #[derive(Debug, Error)]
 pub enum HTMLBackendCompilationError {
@@ -34,9 +29,9 @@ pub enum HTMLBackendCompilationError {
     CouldNotReadTemplate(#[from] std::io::Error),
 }
 
-fn get_template() -> Result<String, std::io::Error> {
-    let template_path = OPTIONS.lock().unwrap().template_path.clone();
-    match template_path.as_ref() {
+#[allow(clippy::option_if_let_else)]
+fn get_template(template_path: Option<String>) -> Result<String, std::io::Error> {
+    match template_path {
         None => Ok(include_str!("../../data/template.html").to_string()),
         Some(path) => std::fs::read_to_string(path),
     }
@@ -58,24 +53,37 @@ impl ToHTML for Event {
     }
 }
 
-impl HTMLBackend {
-    /// Configure the HTML backend
-    ///
-    /// # Arguments
-    ///
-    /// * `opts` - The options to use, see [`HTMLBackendOptions`]
-    ///
-    pub fn configure(opts: HTMLBackendOptions) {
-        *OPTIONS.lock().unwrap() = opts;
+impl CompilingPass<Vec<Event>> for HTMLBackend {
+    type Residual = String;
+    type Error = HTMLBackendCompilationError;
+    fn apply(events: Vec<Event>) -> Result<Self::Residual, Self::Error> {
+        Self::apply_with(
+            events,
+            HTMLBackendOptions {
+                template_path: None,
+            },
+        )
     }
 }
 
-impl CompilingPass<Vec<Event>> for HTMLBackend {
+impl CompilingPass<Vec<Event>, HTMLBackendOptions> for HTMLBackend {
     type Residual = String;
     type Error = HTMLBackendCompilationError;
 
     fn apply(events: Vec<Event>) -> Result<Self::Residual, Self::Error> {
-        let template = get_template()?;
+        Self::apply_with(
+            events,
+            HTMLBackendOptions {
+                template_path: None,
+            },
+        )
+    }
+
+    fn apply_with(
+        events: Vec<Event>,
+        options: HTMLBackendOptions,
+    ) -> Result<Self::Residual, Self::Error> {
+        let template = get_template(options.template_path)?;
         let mut str = String::new();
         str.push_str("<table><tbody>\n");
         for i in 9..21 {


### PR DESCRIPTION
Add support for multiple backend and add an HTML backend to the compiler.

Add new options for the compiler, namely
```
  -f, --format <FORMAT>      Output format [default: tikz]
  -t, --template <TEMPLATE>  Template to use, if any
  -o, --output <FILE>        Output file. If not present, will output to stdout
̀```