### PR TITLE
Add a couple more files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 /target
+
+# Common files that would come from the compilation of a pdf, typically with
+# pdflatex.
+/*.aux
+/*.log
+/*.pdf
+/*.tex
+
+# HTML output
+/*.html


### PR DESCRIPTION
Since we are going to compile PDFs externally (for a little bit longer), we may want to spare ourselves accidental addition of potential intermediate and output files to the repository.

I also pre-emptively added `*.html`, since we will definitely compile towards HTML at some point in the near future.

---

Everything I added is only ignored at the root, which is where we are most likely to accidentally leave intermediate files. If we want other locations, and other files, let me know, and I will change my gitignore accordingly.