### PR TITLE
Move `CompilingPass` input type to a GAT/TAT

### DIFF
--- a/src/passes.rs
+++ b/src/passes.rs
@@ -5,7 +5,9 @@ pub mod parser;
 
 /// A trait defining compilation passes
 /// Compilation passes should be chainable
-pub trait CompilingPass<T> {
+pub trait CompilingPass {
+    /// Type of input data
+    type Input<'a>;
     /// Type of data that is returned by the pass if it succeeds.
     type Residual;
     /// Type of errors that the pass returns when it fails.
@@ -16,7 +18,7 @@ pub trait CompilingPass<T> {
     /// # Errors
     ///
     /// May return errors if type is not compatible
-    fn apply(_: T) -> Result<Self::Residual, Self::Error>;
+    fn apply<'a>(_: Self::Input<'a>) -> Result<Self::Residual, Self::Error>;
 }
 
 /// A trait to be able to chain compilation passes
@@ -26,9 +28,9 @@ pub trait PassInput: Sized {
     /// # Errors
     ///
     /// Can return a fitting error if a compilation pass cannot be applied.
-    fn chain_pass<P>(self) -> Result<P::Residual, P::Error>
+    fn chain_pass<'a, P>(self) -> Result<P::Residual, P::Error>
     where
-        P: CompilingPass<Self>,
+        P: CompilingPass<Input<'a> = Self>,
     {
         P::apply(self)
     }

--- a/src/passes/latex.rs
+++ b/src/passes/latex.rs
@@ -210,7 +210,8 @@ fn speaker_string(e: &Event) -> String {
     }
 }
 
-impl CompilingPass<Vec<Event>> for TikzBackend {
+impl CompilingPass for TikzBackend {
+    type Input<'a> = Vec<Event>;
     type Residual = String;
     type Error = TikzBackendCompilationError;
 

--- a/src/passes/parser.rs
+++ b/src/passes/parser.rs
@@ -29,7 +29,8 @@ use std::str::FromStr;
 /// ```
 pub struct ParseTimetable {}
 
-impl CompilingPass<&str> for ParseTimetable {
+impl CompilingPass for ParseTimetable {
+    type Input<'a> = &'a str;
     type Residual = Vec<Event>;
     type Error = <Event as FromStr>::Err;
 


### PR DESCRIPTION
Following a discussion had with the core maintainer of the project, we wondered if it would be possible (and also preferable, but that is another question), to move the input type of a `CompilingPass` to be a generic type associated to the trait implementation rather than a pure generics of the trait.

The obvious advantages of having generics are that it is more intuitive for developers. It is also less of a concrete type, so no lifetimes are necessary. The downsides are that we never really need the same type implementing `CompilingPass` to also implement the same pass on another type that cannot be trivially converted using a method such as `.into()`.

On the other hand, the upside of using a type associated to the trait is that it is more coherent with the fact that the output type is already specified that way. It also formally restricts the fact that a single structure will only ever perform one type of pass over one type of input data. The downside is that in cases where it is necessary to specify a lifetime (notably when references, such as `&str` are involved), we need to move the TAT to be a Generic Associated Type (GAT), with an associated generic lifetime. The syntax is a bit less common, but not much more verbose. The generic lifetime still needs to be specified even for types that do not need it however.

---

This commit is a proof of work of this modification, to invite discussion among the developers, and show ways that the `CompilingPass` could be thought of. I'm not entirely sure we would want this, but it's interesting to know it exists.