### PR TITLE
[WIP] Updated HTML template

### DIFF
--- a/data/template.html
+++ b/data/template.html
@@ -12,25 +12,29 @@
         font-size: large;
       }
 
-      .meal {
-      }
-      .fun {
-      }
-
-      .talk {
-      }
-
       .event {
-        color: #3a3b3d;
+        color: #46494C;
         border: 2px solid #696969;
         padding: 1em;
         font-size: 25pt;
+        background-color: white;
       }
 
       .event:hover {
         background-color: #e33729;
         border-color: #e33729;
         color: white;
+      }
+
+      .meal {
+        background-color: #DCDCDD;
+      }
+      .fun {
+        color: #46494C;;
+        background-color: #1985A1;
+      }
+
+      .talk {
       }
 
       .other {
@@ -44,6 +48,7 @@
         margin-left: 3%;
         margin-right: 3%;
         vertical-align: top;
+        background-color: white;
       }
 
       .title:hover {

--- a/data/template.html
+++ b/data/template.html
@@ -1,63 +1,107 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>My template</title>
+    <title>My Seminar</title>
     <style>
       body {
         display: flex;
         align-items: center;
         justify-content: center;
         flex-direction: column;
-
-      }
-
-      table {
-        width: 100%;
-        max-width: 50rem;
-        font-family: -system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-      }
-
-      th {
-        font-weight: normal;
-        border-top: thin dotted #ccc;
-      }
-
-      td {
-        font-size: 0.8rem;
-        font-weight: bold;
-        line-height: 1.4;
-        border-radius: 0.2rem;
-        transition: opacity 0.3s ease;
-        width: 40%;
-      }
-
-      td > span {
-        font-size: 0.8em;
-        font-weight: normal;
-        display: block;
-        width: 100%;
+        font-family: "Source Sans Pro";
+        font-size: large;
       }
 
       .meal {
-        background-color: #ffa726;
       }
       .fun {
-        background-color: #9ccc65;
       }
+
       .talk {
-        background-color: #ff8a65;
       }
+
+      .event {
+        color: #3a3b3d;
+        border: 2px solid #696969;
+        padding: 1em;
+        font-size: 25pt;
+      }
+
+      .event:hover {
+        background-color: #e33729;
+        border-color: #e33729;
+        color: white;
+      }
+
       .other {
         background-color: #b3e5fc;
       }
 
-      .light {
-        color: #ccc;
-        font-weight: normal;
+      .day {
+        display: inline-block;
+        width: 90%;
+        min-width: 180px;
+        margin-left: 3%;
+        margin-right: 3%;
+        vertical-align: top;
+      }
+
+      .title:hover {
+        color: white;
+      }
+
+      .title {
+        font-size: x-large;
+      }
+
+      .abstract {
+        text-align: left;
+        display: none;
+        font-size: large;
+      }
+
+      .calendar {
+        text-align: center;
+        display: inline-block;
+        width: 100%;
+      }
+
+      @media only screen and (min-width: 1200px) {
+        .calendar {
+          width: 60%;
+        }
+
+        .day {
+          width: 40%;
+        }
       }
     </style>
+    <script type="text/javascript">
+      function setup_collapsible() {
+        var coll = document.getElementsByClassName("event");
+        var i;
+        for (i = 0; i < coll.length; i++) {
+          let abstracts = coll[i].getElementsByClassName("abstract");
+          if (abstracts.length > 0) {
+            coll[i].addEventListener("click", function () {
+              this.style.height = "auto";
+              let abstracts = this.getElementsByClassName("abstract");
+              for (let i = 0; i < abstracts.length; i++)
+                if (abstracts[i].style.display == "none") {
+                  abstracts[i].style.display = "block";
+                } else {
+                  abstracts[i].style.display = "none";
+                }
+            });
+          }
+        }
+      }
+      window.onload = setup_collapsible;
+    </script>
   </head>
   <body>
-    {{ CALENDAR }}
+    <h2>My Seminar</h2>
+    Click on the events to display their description
+    <div class="calendar">{{ CALENDAR }}</div>
   </body>
 </html>

--- a/src/event.rs
+++ b/src/event.rs
@@ -172,7 +172,8 @@ impl FromStr for Event {
                     .map_err(|err| ParsingError::CouldNotParseDuration { source: err })
             })?;
         let speakers = settings.get("speakers").map_or_else(Vec::new, |l| {
-            l.split(',')
+            l.replace(['[', ']'], "")
+                .split(',')
                 .map(|s| s.trim().to_owned())
                 .filter(|s| !s.is_empty())
                 .collect()

--- a/src/passes/html.rs
+++ b/src/passes/html.rs
@@ -55,8 +55,11 @@ impl ToHTML for Event {
         res += format!("<b>{}</b><br>", self.title).as_str();
         if !self.speakers.is_empty() {
             res += "<span>";
-            for speaker in &self.speakers {
+            for (i, speaker) in self.speakers.iter().enumerate() {
                 res.push_str(speaker.as_str());
+                if i != self.speakers.len() - 1 {
+                    res += ", ";
+                }
             }
             res += "</span>";
         }

--- a/src/passes/html.rs
+++ b/src/passes/html.rs
@@ -4,7 +4,7 @@ use crate::{
     passes::CompilingPass,
 };
 use chrono::{Datelike, Duration};
-use std::{cmp::min, str::FromStr};
+use std::str::FromStr;
 use thiserror::Error;
 
 /// Backend outputing events to a standalone HTML document containing a timetable
@@ -52,8 +52,7 @@ impl ToHTML for Event {
 
         // Display the title and author of the event
         res += "<div class=\"title\">";
-        let (title, _) = self.title.split_at(min(self.title.len(), 25));
-        res += format!("<b>{title}</b><br>").as_str();
+        res += format!("<b>{}</b><br>", self.title).as_str();
         if !self.speakers.is_empty() {
             res += "<span>";
             for speaker in &self.speakers {

--- a/src/passes/html.rs
+++ b/src/passes/html.rs
@@ -1,6 +1,9 @@
 //! HTML backend
-use crate::{event::Event, passes::CompilingPass};
-use chrono::Timelike;
+use crate::{
+    event::{find_bounding_box, Event, InvalidDatetime},
+    passes::CompilingPass,
+};
+use chrono::{Datelike, Duration};
 use std::{cmp::min, str::FromStr};
 use thiserror::Error;
 
@@ -27,6 +30,9 @@ pub enum HTMLBackendCompilationError {
     /// An error occurred while trying to read the template file
     #[error("Error while trying to read the template file: {0}")]
     CouldNotReadTemplate(#[from] std::io::Error),
+    /// The datetime of either the first day or last day of the bounding box is not valid.
+    #[error(transparent)]
+    InvalidDatetime(#[from] InvalidDatetime),
 }
 
 #[allow(clippy::option_if_let_else)]
@@ -39,16 +45,34 @@ fn get_template(template_path: Option<String>) -> Result<String, std::io::Error>
 
 impl ToHTML for Event {
     fn to_html(&self) -> String {
-        let duration = std::cmp::max(self.duration / 30, 1);
+        let duration = self.duration * 100 / (8 * 60);
         let class = self.event_type.to_string();
-        let mut res = format!("\t\t<td class=\"{class}\" rowspan=\"{duration}\">");
+        // Create a div for the event
+        let mut res = format!("\t<div class=\"event {class}\" style=\"height: {duration}%;\">");
+
+        // Display the title and author of the event
+        res += "<div class=\"title\">";
         let (title, _) = self.title.split_at(min(self.title.len(), 25));
-        res.push_str(title);
-        res.push_str("<span>");
-        for speaker in &self.speakers {
-            res.push_str(speaker.as_str());
+        res += format!("<b>{title}</b><br>").as_str();
+        if !self.speakers.is_empty() {
+            res += "<span>";
+            for speaker in &self.speakers {
+                res.push_str(speaker.as_str());
+            }
+            res += "</span>";
         }
-        res.push_str("</span></td>\n");
+        res += "</div>\n";
+
+        // Display the abstract of the event
+        if let Some(description) = &self.description {
+            res += format!(
+                "<div class=\"abstract\"><br>{}</div>",
+                description.replace('\n', "<br>")
+            )
+            .as_str();
+        }
+        res += "</div>";
+
         res
     }
 }
@@ -84,20 +108,42 @@ impl CompilingPass<Vec<Event>, HTMLBackendOptions> for HTMLBackend {
         options: HTMLBackendOptions,
     ) -> Result<Self::Residual, Self::Error> {
         let template = get_template(options.template_path)?;
+
+        // Find the number of days and the first day of the events
+        let bounding_box = find_bounding_box(&events).ok_or(InvalidDatetime {})?;
+        let nb_days = bounding_box.last_day()?.day() - bounding_box.first_day().unwrap().day() + 1;
+        let first_day = bounding_box.first_day()?.date_naive();
+
         let mut str = String::new();
-        str.push_str("<table><tbody>\n");
-        for i in 9..21 {
-            str.push_str(format!("\t<tr><th>{i}:00</th>").as_str());
-            for event in events
+        // Create a div for each day, containing the event of the day
+        for i in 0..nb_days {
+            let curr_day = first_day + Duration::days(i64::from(i));
+            let mut day_events: Vec<&Event> = events
                 .iter()
-                .filter(|ev| ev.start_date.hour() >= i && ev.start_date.hour() < i + 1)
-            {
-                str.push_str(event.to_html().as_str());
+                .filter(|ev| ev.start_date.date_naive() == curr_day)
+                .collect();
+            day_events.sort_by_key(|e| e.start_date.time());
+
+            str += "<div class=\"day\">";
+            str.push_str(format!("<h2>{}</h2>", curr_day.format("%A, %B %e")).as_str());
+            let mut previous_hour = None;
+            for event in day_events {
+                // Display the start time, if needed
+                if previous_hour.is_none() || previous_hour.unwrap() == event.start_date {
+                    // Display the end time
+                    str += event.start_date.format("%H:%M").to_string().as_str();
+                    previous_hour = Some(event.start_date);
+                }
+                // Display the event
+                str += event.to_html().as_str();
+                // Display the end time
+                str += (event.start_date + Duration::minutes(i64::from(event.duration)))
+                    .format("%H:%M")
+                    .to_string()
+                    .as_str();
             }
-            str.push_str("</tr>\n");
-            str.push_str(format!("\t<tr><th class=\"light\">{i}:30</th></tr>\n").as_str());
+            str += "</div>";
         }
-        str.push_str("</tbody></table>\n");
         Ok(template.replace("{{ CALENDAR }}", &str))
     }
 }

--- a/src/passes/html.rs
+++ b/src/passes/html.rs
@@ -65,8 +65,8 @@ impl ToHTML for Event {
         // Display the abstract of the event
         if let Some(description) = &self.description {
             res += format!(
-                "<div class=\"abstract\"><br>{}</div>",
-                description.replace('\n', "<br>")
+                "<div class=\"abstract\"><p>{}</p></div>",
+                description.replace("\n\n", "</p><p>")
             )
             .as_str();
         }


### PR DESCRIPTION
The old HTML template used a table to create the planning. With this setup, it was complicated to deal with events not starting at round hours (8h, 9h, ...).

Thus, the template has been replaced with a list of events, with the ability to show the description of an event on a simple click. I also changed the style to match the [Pacap Website](https://team.inria.fr/pacap/).

Here is how it look like on a laptop

![image](https://user-images.githubusercontent.com/20738355/231432369-d457a461-cf28-43a7-abef-8145809ad238.png)

Here is how it look like on mobile:

![image](https://user-images.githubusercontent.com/20738355/231432855-16815e2e-a17c-4136-acbf-40cc693aaee7.png)

There are still some work to do:
- [ ] Separate the authors name
- [ ] Find a separate color for lunch/dinner times

I don't know yet if the description of the event should be visible from the start or if we want the user to click on it.
Any feedback on the new template/style ? Any idea to improve it ?