### PR TITLE
✨ Added Latexmk backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,13 +234,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -235,7 +252,7 @@ dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -249,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "link-cplusplus"
@@ -303,6 +320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +344,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,7 +384,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -346,6 +399,8 @@ version = "0.1.4"
 dependencies = [
  "chrono",
  "clap",
+ "glob",
+ "rand",
  "thiserror",
 ]
 
@@ -413,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -434,6 +489,12 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -526,7 +587,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -535,7 +596,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -544,13 +614,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -560,10 +645,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -572,10 +669,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -584,13 +693,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ keywords = ["timetable"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.1.13", features = ["derive"] }
-chrono = "0.4.24"
+clap = { version = "4.*", features = ["derive"] }
+chrono = "0.4.*"
 thiserror = "1.0.*"
+rand = "0.8.*"
+glob = "0.3.*"

--- a/src/event.rs
+++ b/src/event.rs
@@ -232,7 +232,7 @@ impl BoundingBox {
 
     /// Get how many days the event is lasting
     #[must_use]
-    pub fn nb_days(&self) -> u32{
+    pub fn nb_days(&self) -> u32 {
         let duration = self.down_right.day() - self.up_left.day();
         duration + 1
     }
@@ -312,7 +312,12 @@ pub fn find_bounding_box(events: &Vec<Event>) -> Option<BoundingBox> {
 
 #[cfg(test)]
 fn create_empty_datetime() -> DateTime<Local> {
-    NaiveDate::from_ymd_opt(0, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap().and_local_timezone(Local).unwrap()
+    NaiveDate::from_ymd_opt(0, 1, 1)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_local_timezone(Local)
+        .unwrap()
 }
 #[test]
 fn test_number_days() {
@@ -320,15 +325,19 @@ fn test_number_days() {
     let dur = create_empty_datetime().with_hour(18).unwrap();
     let bb = BoundingBox {
         down_right: dur,
-        up_left: create_empty_datetime()
+        up_left: create_empty_datetime(),
     };
     assert!(bb.nb_days() == 1);
 
     // Test for an event spanning on two days (1 January 0h -> 2 January 18h)
-    let dur = create_empty_datetime().with_day(2).unwrap().with_hour(18).unwrap();
+    let dur = create_empty_datetime()
+        .with_day(2)
+        .unwrap()
+        .with_hour(18)
+        .unwrap();
     let bb = BoundingBox {
         down_right: dur,
-        up_left: create_empty_datetime()
+        up_left: create_empty_datetime(),
     };
     assert!(bb.nb_days() == 2);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,10 +128,10 @@ fn generate_html(options: HTMLBackendOptions, content: &str) -> Result<Vec<u8>, 
         .map_err(CompilerError::from)
 }
 
-fn open_output_file(path: Option<String>) -> Result<fs::File, std::io::Error> {
+fn open_output_file(path: Option<String>) -> Result<Box<dyn Write>, std::io::Error> {
     match path {
-        Some(p) => fs::File::create(p),
-        None => todo!(),
+        Some(p) => Ok(fs::File::create(p).map(Box::new)?),
+        None => Ok(Box::new(std::io::stdout())),
     }
 }
 
@@ -147,7 +147,7 @@ fn open_output_file(path: Option<String>) -> Result<fs::File, std::io::Error> {
 /// * `Ok(())` if the output was written successfully
 /// * `Err(std::io::Error)` if the output could not be written
 ///
-fn write_output(output: &mut fs::File, data: &[u8]) -> Result<(), std::io::Error> {
+fn write_output(output: &mut impl Write, data: &[u8]) -> Result<(), std::io::Error> {
     output.write_all(data)
 }
 

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -2,6 +2,7 @@
 
 pub mod html;
 pub mod latex;
+pub mod latexmk;
 pub mod parser;
 
 /// A trait defining compilation passes

--- a/src/passes/latex.rs
+++ b/src/passes/latex.rs
@@ -1,4 +1,4 @@
-//! Latex frontends
+//! Latex backends
 
 use std::str::FromStr;
 
@@ -10,16 +10,16 @@ use crate::{
     passes::CompilingPass,
 };
 
-/// Backend outputing events to a standalone LaTeX document containing a Tikz timetable
+/// Backend outputing events to a standalone LaTeX document containing a `TikZ` timetable
 pub struct TikzBackend {}
 
-/// Options for the HTML backend
+/// Options for the `TikZ` backend
 pub struct TikzBackendOptions {
     /// Path to the template file. If not set, the default template (`data/template_tikz.tex`) will be used.
     pub template_path: Option<String>,
 }
 
-/// Error occuring when compiling an event list to tikz.
+/// Error occuring when compiling an event list to `TikZ`.
 #[derive(Debug, Error)]
 pub enum TikzBackendCompilationError {
     /// The event could not be parsed.
@@ -82,12 +82,13 @@ fn hour_marks(first_hour: u32, last_hour: u32) -> String {
     // For each hour, write it on the left
     foreach_hour(first_hour, last_hour)
         + r"
-            \node[anchor=east] at (1,\time) {\time:00};"
+        \node[anchor=east] at (1,\time) {\time:00};"
 }
 
 /// Generate a tikz node in the calendar for a given event
 fn tikz_node(e: &Event, up_left_day: u32) -> String {
-    r"\node[".to_owned()
+    r"
+    \node[".to_owned()
         // declare the event type for the format
         + &format!("{}", e.event_type)
         + "={"
@@ -119,7 +120,7 @@ fn day_dividers(first_hour: u32, last_hour: u32, day_count: u32) -> String {
         .to_owned()
         + &format!("{{1,...,{}}}", day_count + 1)
         + r"
-            \draw (\day,"
+        \draw (\day,"
         + &format!("{}", first_hour - 1)
         + r") -- (\day,"
         + &format!("{last_hour}")
@@ -133,7 +134,7 @@ fn date_headers(first_hour: u32, day_count: u32, up_left: DateTime<Local>) -> St
     for i in 0..day_count {
         let col = i + 1;
         r += r"
-        \node[anchor=south] at (";
+    \node[anchor=south] at (";
         r += &format!("{col}");
         r += r".5, ";
         r += &format!("{}", first_hour - 1);

--- a/src/passes/latexmk.rs
+++ b/src/passes/latexmk.rs
@@ -1,0 +1,137 @@
+//! Will call eventually call Latexmk on a previous pass input
+
+use glob::glob;
+use rand::Fill;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use crate::passes::CompilingPass;
+
+/// Options for Latexmk call pass
+pub struct Options {
+    /// Path of the input file
+    pub input_path: Option<String>,
+    /// Path of the output file
+    pub output_path: Option<String>,
+    /// Save temporary files
+    pub save_temps: bool,
+}
+
+use thiserror::Error;
+
+/// Error occurring when compiling an event list to `TikZ`.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Error from launching Latexmk
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+    /// Error on temporary file creation
+    #[error(transparent)]
+    CouldNotCreateTempFile(#[from] TempFileCreationError),
+}
+
+/// Will call Latexmk with the `$pdflatex` target, if found on the system
+pub struct Pass {}
+
+/// Error occurring when creating a temporary file
+#[derive(Debug, Error)]
+pub enum TempFileCreationError {
+    /// Error returned from random generator
+    #[error("Error while trying to generate a random string: {0}")]
+    CouldNotCreateRandomString(#[from] rand::Error),
+}
+
+/// Generate a random String of size `len` that should be valid as a file name
+///
+/// # Errors
+///
+/// On file temporary creation, RNG or io errors can happen
+fn random_filename(len: usize) -> Result<String, TempFileCreationError> {
+    let alphabet: Vec<char> = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        .chars()
+        .collect();
+    let alpabet_length = alphabet.len();
+
+    let mut rng = rand::thread_rng();
+
+    let mut src: Vec<u8> = vec![0; len];
+
+    src.try_fill(&mut rng)?;
+
+    Ok(src
+        .into_iter()
+        .map(|l| alphabet[l as usize % alpabet_length])
+        .collect())
+}
+
+fn tex_pathbuf_from_random_string(len: usize) -> Result<PathBuf, TempFileCreationError> {
+    Ok(PathBuf::from(random_filename(len)? + ".tex"))
+}
+
+/// Will try to get a random file name that does not exist
+///
+/// # Errors
+///
+/// Errors can happen in RNG or on IO operations.
+pub fn random_valid_filename(len: usize) -> Result<PathBuf, TempFileCreationError> {
+    let mut filepath = tex_pathbuf_from_random_string(len)?;
+
+    while filepath.exists() {
+        filepath = tex_pathbuf_from_random_string(len)?;
+    }
+
+    Ok(filepath)
+}
+
+// TODO Error management, get rid of unwraps
+fn cleanup(input_path: &Path) {
+    for entry in glob(input_path.with_extension("*").to_str().unwrap()).unwrap() {
+        let e = entry.unwrap();
+        if e.is_file() {
+            if let Err(err) = fs::remove_file(e) {
+                eprintln!("[Warning] Could not delete temporary file: {err}");
+            }
+        }
+    }
+}
+
+impl CompilingPass<&str, Options> for Pass {
+    type Residual = Vec<u8>;
+    type Error = Error;
+    fn apply_with(latex: &str, options: Options) -> Result<Self::Residual, Self::Error> {
+        let input_file = options
+            .input_path
+            .map_or_else(|| random_valid_filename(16), |s| Ok(PathBuf::from(s)));
+
+        let input_unwrapped = input_file?;
+
+        fs::write(&input_unwrapped, latex)?;
+
+        let latexmk = Command::new("latexmk")
+            .arg("-pdflua")
+            .arg(&input_unwrapped)
+            .spawn()?;
+
+        latexmk.wait_with_output().expect("failed to wait on child");
+
+        let ret = fs::read(input_unwrapped.with_extension("pdf")).map_err(Error::from);
+
+        cleanup(&input_unwrapped);
+
+        ret
+    }
+
+    fn apply(latex: &str) -> Result<Self::Residual, Self::Error> {
+        Self::apply_with(
+            latex,
+            Options {
+                input_path: None,
+                output_path: None,
+                save_temps: false,
+            },
+        )
+    }
+}


### PR DESCRIPTION
**Changes impacting existing code**
- Changed `generate_*` outputs in main to `Vec<u8>` to be able to output binary files instead of `String` only
- Switched parameters of `write_output` to:
  - `&mut std::fs::File` to be able to open any file
  - `&[u8]` to open binary data
- `main` now returns a result so error management can be simplified
- `open_output_file` will open a file and should return a way to write to standard output if no file is given

**For Latexmk backend**
- The pass takes an option consisting of:
  - An input file
  - An output file (still unused for now)
  - Whether we should save temporary files (still unused for now)
- If no input path is given, the pass will generate a temporary file
- Ultimately, the pass will call `latexmk -pdflua`

**Small changes**
- Added `save_tmp` cli option
- Switched to any minor dependencies in `Cargo.toml` to get bug fixes
- Removed a Clippy lint (was keeping to ask for changes that made code hard to read)
- Fixed a few typos in comments
- Ran `cargo fmt`

**Still TODO**
 - [x] Output to stdout if no output file is given
 - [x] Cleanup the cleanup function to get rid of unwraps